### PR TITLE
Added optional host field for /v3/status path in Ingress configuration (#2)

### DIFF
--- a/cryptlex/cryptlex-enterprise/templates/ingress.yaml
+++ b/cryptlex/cryptlex-enterprise/templates/ingress.yaml
@@ -119,4 +119,7 @@ spec:
                 name: {{ .Release.Name }}-web-api-service
                 port: 
                   number: 5000
-            pathType: ImplementationSpecific 
+            pathType: ImplementationSpecific
+            {{- if .Values.ingress.hosts.webApiHostStatus }}
+            host: "{{ .Values.ingress.hosts.webApiHostStatus }}"
+            {{- end }}

--- a/cryptlex/cryptlex-enterprise/values.yaml
+++ b/cryptlex/cryptlex-enterprise/values.yaml
@@ -23,6 +23,8 @@ ingress:
   hosts:
     # Hostname of the Cryptlex Web API server.
     webApiHost: cryptlex-api.mycompany.com
+    # Optional hostname of the Cryptlex /v3/status path.
+    webApiHostStatus: 
     # Hostname of the Cryptlex Admin Portal server
     adminPortalHost: cryptlex-app.mycompany.com
     # Hostname of the Cryptlex Customer Portal server


### PR DESCRIPTION
## **User description**
This PR addresses issue #2  by adding an optional host field for the /v3/status path in the Ingress configuration. This modification allows for flexibility in routing traffic to the {{ .Release.Name }}-web-api-service service while avoiding conflicts with the main host.


___

## **Type**
enhancement


___

## **Description**
- Introduced an optional `host` field for the `/v3/status` path in the Ingress configuration to enhance routing flexibility.
- This change allows specifying a host for the `/v3/status` path, making it easier to manage traffic and avoid conflicts.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ingress.yaml</strong><dd><code>Add Optional Host Field for /v3/status in Ingress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
cryptlex/cryptlex-enterprise/templates/ingress.yaml

<li>Added an optional <code>host</code> field for the <code>/v3/status</code> path in the Ingress <br>configuration.<br> <li> The <code>host</code> field is conditional, based on the <br><code>.Values.ingress.hosts.webApiHostStatus</code> value.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cryptlex/helm-charts/pull/3/files#diff-8611c7c131d26c28a72613f271ea3c2f242c739f9dcd9e2d9abf892bb3022ca4">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

